### PR TITLE
[fix][broker] Avoid producer latency rise

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2451,11 +2451,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     @Override
     public void trimConsumedLedgersInBackground(CompletableFuture<?> promise) {
-        executor.execute(() -> internalTrimConsumedLedgers(promise));
+        scheduledExecutor.execute(() -> internalTrimConsumedLedgers(promise));
     }
 
     public void trimConsumedLedgersInBackground(boolean isTruncate, CompletableFuture<?> promise) {
-        executor.execute(() -> internalTrimLedgers(isTruncate, promise));
+        scheduledExecutor.execute(() -> internalTrimLedgers(isTruncate, promise));
     }
 
     private void scheduleDeferredTrimming(boolean isTruncate, CompletableFuture<?> promise) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2459,7 +2459,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     private void scheduleDeferredTrimming(boolean isTruncate, CompletableFuture<?> promise) {
-        scheduledExecutor.schedule(() -> trimConsumedLedgersInBackground(isTruncate, promise),
+        scheduledExecutor.schedule(() -> internalTrimLedgers(isTruncate, promise),
                 100, TimeUnit.MILLISECONDS);
     }
 
@@ -4235,9 +4235,9 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             futures.add(future);
         }
         CompletableFuture<Void> future = new CompletableFuture();
-        FutureUtil.waitForAll(futures).thenAccept(p -> {
+        FutureUtil.waitForAll(futures).thenAcceptAsync(p -> {
             internalTrimLedgers(true, future);
-        }).exceptionally(e -> {
+        }, scheduledExecutor).exceptionally(e -> {
             future.completeExceptionally(e);
             return null;
         });


### PR DESCRIPTION
### Motivation
The executor in `ManagedLedgerImpl` uses the `MainWorkerPool` of bookKeeper, and both produce and consume use this thread pool.

When there are a large number of partitions in the cluster and the cluster is busy, trim ledger will cause the produce latency to rise from hundreds of milliseconds to seconds. We found that a large number of tasks are stuck in the queue of the thread pool

Trim ledger is a thread-safe operation and has no latency requirements, so we'd better separate it from `MainWorkerPool` of bookKeeper

### Modifications
Separate it from `MainWorkerPool` of bookKeeper

### Verifying this change


### Documentation
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->

### Matching PR in forked repository

